### PR TITLE
Maintain clients

### DIFF
--- a/src/TextbrokerClient.php
+++ b/src/TextbrokerClient.php
@@ -11,6 +11,10 @@ class TextbrokerClient
     protected $url;
     protected $salt;
     protected $token;
+    protected $budgetOrderCheckClient;
+    protected $budgetOrderServiceClient;
+    protected $budgetOrderChangeClient;
+    protected $loginClient;
 
     public function __construct($budgetID, $budgetKey, $budgetPassword, $platformCode = "us")
     {
@@ -33,32 +37,57 @@ class TextbrokerClient
         );
         $this->platform = $platformCode;
         $this->url = $platformArr[$platformCode];
+
+        
+
+        // instantiate the login client
+        $loginOptions = array(
+            'location' => $this->url . "loginService.php",
+            'uri' => $this->url,
+            'keep_alive' => false,
+        );
+
+        $this->loginClient = new \SoapClient(null, $loginOptions);
+        
+        // instantiate the budgetORderCheck client
+        $budgetOrderCheckOptions = array(
+            'location' => $this->url . 'budgetCheckService.php',
+            'uri' => $this->url,
+            'keep_alive' => false,
+        );
+
+        $this->budgetOrderCheckClient = new \SoapClient(null, $budgetOrderCheckOptions);
+
+
+        //instantiate the budgetOrderServiceClient
+        $budgetOrderServiceOptions = array(
+            'location' => $this->url . 'budgetOrderService.php',
+            'uri' => $this->url,
+            'keep_alive' => false,
+        );
+
+        $this->budgetOrderServiceClient = new \SoapClient(null, $budgetOrderServiceOptions);
+
+        // instantiate the budgetOrderChange client
+        $budgetOrderChangeOptions = array(
+            'location' => $this->url . 'budgetOrderChangeService.php',
+            'uri' => $this->url,
+            'keep_alive' => false,
+        );
+
+        $this->budgetOrderChangeClient = new \SoapClient(null, $budgetOrderChangeOptions);
+
         $this->logIn();
     }
 
     protected function logIn()
     {
-        $location = $this->url . "loginService.php";
-        $loginOptions = array(
-            'location' => $location,
-            'uri' => $this->url,
-            'keep_alive' => false,
-        );
-
-        $loginClient = new \SoapClient(null, $loginOptions);
         $response = $loginClient->doLogin($this->salt, $this->token, $this->budgetKey);
     }
 
     protected function budgetCheckService(string $method)
     {
-        $location = $this->url . 'budgetCheckService.php';
-        $options = array(
-            'location' => $location,
-            'uri' => $this->url,
-            'keep_alive' => false,
-        );
-        $client = new \SoapClient(null, $options);
-        return $client->$method($this->salt, $this->token, $this->budgetKey);
+        return $this->budgetOrderCheckClient->$method($this->salt, $this->token, $this->budgetKey);
     }
 
     public function getClientBalance()
@@ -89,20 +118,14 @@ class TextbrokerClient
 // budgetOrderService
     protected function budgetOrderService(string $method, array $params = [])
     {
-        $location = $this->url . 'budgetOrderService.php';
-        $options = array(
-            'location' => $location,
-            'uri' => $this->url,
-            'keep_alive' => false,
-        );
-        $client = new \SoapClient(null, $options);
         $login = array(
             $this->salt,
             $this->token,
             $this->budgetKey
         );
         $args = array_merge($login, $params);
-        return $client->$method(...$args);
+
+        return $this->budgetOrderServiceClient->$method(...$args);
     }
 
     public function getCategories()
@@ -233,20 +256,13 @@ class TextbrokerClient
     
     protected function budgetOrderChangeService(string $method, array $params = [])
     {
-        $location = $this->url . 'budgetOrderChangeService.php';
-        $options = array(
-            'location' => $location,
-            'uri' => $this->url,
-            'keep_alive' => false,
-        );
-        $client = new \SoapClient(null, $options);
         $login = array(
             $this->salt,
             $this->token,
             $this->budgetKey
         );
         $args = array_merge($login, $params);
-        return $client->$method(...$args);
+        return $this->budgetOrderChangeClient->$method(...$args);
     }
 
     public function setSEO(int $orderID, array $keywords, int $minDensity = 0, int $maxDensity = 0, bool $inflections = true, bool $stopwords = true)

--- a/src/TextbrokerClient.php
+++ b/src/TextbrokerClient.php
@@ -41,17 +41,21 @@ class TextbrokerClient
         
 
         // instantiate the login client
+        $loginEndpoint = $this->url . "loginService.php";
+
         $loginOptions = array(
-            'location' => $this->url . "loginService.php",
+            'location' => $loginEndpoint,
             'uri' => $this->url,
             'keep_alive' => false,
         );
 
         $this->loginClient = new \SoapClient(null, $loginOptions);
         
-        // instantiate the budgetORderCheck client
+        // instantiate the budgetOrderCheck client
+        $budgetOrderCheckEndpoint = $this->url . 'budgetCheckService.php';
+
         $budgetOrderCheckOptions = array(
-            'location' => $this->url . 'budgetCheckService.php',
+            'location' => $budgetOrderCheckEndpoint,
             'uri' => $this->url,
             'keep_alive' => false,
         );
@@ -60,8 +64,10 @@ class TextbrokerClient
 
 
         //instantiate the budgetOrderServiceClient
+        $budgetOrderServiceEndpoint = $this->url . 'budgetOrderService.php';
+
         $budgetOrderServiceOptions = array(
-            'location' => $this->url . 'budgetOrderService.php',
+            'location' => $budgetOrderServiceEndpoint,
             'uri' => $this->url,
             'keep_alive' => false,
         );
@@ -69,8 +75,10 @@ class TextbrokerClient
         $this->budgetOrderServiceClient = new \SoapClient(null, $budgetOrderServiceOptions);
 
         // instantiate the budgetOrderChange client
+        $budgetOrderChangeEndpoint = $this->url . 'budgetOrderChangeService.php';
+
         $budgetOrderChangeOptions = array(
-            'location' => $this->url . 'budgetOrderChangeService.php',
+            'location' => $budgetOrderChangeEndpoint,
             'uri' => $this->url,
             'keep_alive' => false,
         );

--- a/src/TextbrokerClient.php
+++ b/src/TextbrokerClient.php
@@ -42,6 +42,7 @@ class TextbrokerClient
         $loginOptions = array(
             'location' => $location,
             'uri' => $this->url,
+            'keep_alive' => false,
         );
 
         $loginClient = new \SoapClient(null, $loginOptions);
@@ -54,6 +55,7 @@ class TextbrokerClient
         $options = array(
             'location' => $location,
             'uri' => $this->url,
+            'keep_alive' => false,
         );
         $client = new \SoapClient(null, $options);
         return $client->$method($this->salt, $this->token, $this->budgetKey);
@@ -91,6 +93,7 @@ class TextbrokerClient
         $options = array(
             'location' => $location,
             'uri' => $this->url,
+            'keep_alive' => false,
         );
         $client = new \SoapClient(null, $options);
         $login = array(
@@ -234,6 +237,7 @@ class TextbrokerClient
         $options = array(
             'location' => $location,
             'uri' => $this->url,
+            'keep_alive' => false,
         );
         $client = new \SoapClient(null, $options);
         $login = array(


### PR DESCRIPTION
Added four SoapClient objects as fields on the TextbrokerClient object. Previously, each request instantiated a new client, which resulted in problems when making large numbers of API calls on systems with limited maximum open files. This should significantly reduce the required number of open files.